### PR TITLE
Fix useWindowWidth hook

### DIFF
--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -2,12 +2,12 @@ import { useState, useEffect } from "react";
 
 
 export default function useWindowWidth() {
-    const [width, setWith] = useState(window.innerWidth);
+    const [width, setWidth] = useState(window.innerWidth);
 
 
     useEffect(() => {
         const handleWindowWidth = () => {
-            setWith(window.innerWidth);
+            setWidth(window.innerWidth);
         }
 
         window.addEventListener('resize', handleWindowWidth);
@@ -17,7 +17,7 @@ export default function useWindowWidth() {
         return () => {
             window.removeEventListener('resize', handleWindowWidth);
         }
-    }, [width]);
+    }, []);
 
 
     return width;


### PR DESCRIPTION
## Summary
- fix useWindowWidth hook

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68416d037144832d9a74dee6a9adeb48