### PR TITLE
Fix registration API base path and error handling

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,8 +1,13 @@
 import axios from 'axios';
 
 const normalizeUrl = (value) => (value || '').replace(/\/+$/, '');
+const ensureApiPrefix = (value) => {
+  const normalized = normalizeUrl(value || '');
+  if (/\/api($|\/)/i.test(normalized)) return normalized;
+  return `${normalized}/api`;
+};
 
-export const API_BASE_URL = normalizeUrl(
+export const API_BASE_URL = ensureApiPrefix(
   import.meta.env.VITE_BACKEND_URL || 'https://4-pets-backend.vercel.app'
 );
 

--- a/src/pages/user-profile/index.jsx
+++ b/src/pages/user-profile/index.jsx
@@ -18,9 +18,11 @@ export default function UserProfile() {
   const interfaceLanguage = useSelector(state => state.language.interfaceLanguage);
   const navigate = useNavigate();
   const lang = allMyLanguageData[interfaceLanguage]?.userProfilePage;
+  const authMessages = allMyLanguageData[interfaceLanguage]?.authenticationPage?.messages || {};
 
   const registrationData = useSelector(state => state.registration);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
   const fileInputRef = useRef(null);
 
   const handleSelectFile = (e) => {
@@ -33,13 +35,28 @@ export default function UserProfile() {
   const triggerFile = () => fileInputRef.current?.click();
 
   useEffect(() => {
-    if (!registrationData.email || !registrationData.password || !registrationData.username) {
+    if (!registrationData.email || !registrationData.password) {
       navigate('/signup');
+      return;
     }
-  }, [registrationData]);
+    if (!registrationData.username || !registrationData.contact) {
+      navigate('/registration');
+    }
+  }, [registrationData, navigate]);
 
   const handleNext = async () => {
     if (loading) return;
+    if (!registrationData.email || !registrationData.password) {
+      navigate('/signup');
+      return;
+    }
+    if (!registrationData.username || !registrationData.contact) {
+      setError(authMessages?.contactInvalid || 'Пожалуйста, заполните данные профиля');
+      navigate('/registration');
+      return;
+    }
+
+    setError('');
     setLoading(true);
     try {
       const formData = new FormData();
@@ -57,6 +74,7 @@ export default function UserProfile() {
       navigate('/success');
     } catch (err) {
       const msg = getErrorMessage(err, 'Ошибка сервера');
+      setError(msg);
       console.error(msg);
     } finally {
       setLoading(false);
@@ -84,8 +102,9 @@ export default function UserProfile() {
             </UserProfileButton>
             <input ref={fileInputRef} type="file" accept="image/*" onChange={handleSelectFile} hidden />
           </div>
+          {error && <div className="user-profile-error">{error}</div>}
           <TheLinkToPageButton
-            buttonText={loading ? allMyLanguageData[interfaceLanguage].authenticationPage.messages.pleaseWait : lang.buttonForRegistrationText}
+            buttonText={loading ? authMessages.pleaseWait : lang.buttonForRegistrationText}
             isPrimary
             isActive={!loading}
             onClick={handleNext}

--- a/src/pages/user-profile/style.scss
+++ b/src/pages/user-profile/style.scss
@@ -54,6 +54,13 @@
       }
     }
   }
+
+  &-error {
+    color: #D5007F;
+    font-size: 14px;
+    text-align: center;
+    max-width: 420px;
+  }
 }
 
 .link-to-page-button.primary {


### PR DESCRIPTION
## Summary
- ensure the API base URL always points to the backend /api prefix used by auth endpoints
- add validation and visible error handling during the profile registration step before calling the backend
- style the profile registration error message so users know why submission failed

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953071fd7d4832d804d0fbda8714a99)