### PR TITLE
Fix registration flow connectivity and routing

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://4petsbackend-production.up.railway.app/
+VITE_BACKEND_URL=https://4-pets-backend.vercel.app

--- a/src/api.js
+++ b/src/api.js
@@ -28,7 +28,7 @@ const readStoredToken = () => {
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  withCredentials: true,
+  withCredentials: false,
   headers: {
     Accept: 'application/json',
   },

--- a/src/components/customSelect/index.jsx
+++ b/src/components/customSelect/index.jsx
@@ -11,6 +11,16 @@ const CustomSelect = ({ options, selected, onChange }) => {
     const interfaceLanguage = useSelector(state => state.language.interfaceLanguage);
     
     
+    useEffect(() => {
+        setSelectedOption(selected || null);
+    }, [selected]);
+
+    useEffect(() => {
+        if (!selected && !selectedOption && options?.length) {
+            const defaultOption = options.find(opt => opt.selected) || options[0];
+            setSelectedOption(defaultOption);
+        }
+    }, [options, selected, selectedOption]);
 
     useEffect(() => {
         const handleClickOutside = (event) => {

--- a/src/pages/profile-registration-page/index.jsx
+++ b/src/pages/profile-registration-page/index.jsx
@@ -1,5 +1,5 @@
 import './style.scss';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Input } from '../../components/input';
 import CustomSelect from '../../components/customSelect';
 import { LinkButton, TheLinkToPageButton } from '../../components/button';
@@ -25,7 +25,17 @@ export default function ProfileRegistrationPage() {
   const [errors, setErrors] = useState({ username: '', contact: '' });
   const [isFormValid, setIsFormValid] = useState(false);
 
-  const validateField = (key, value) => {
+  useEffect(() => {
+    const cityOptions = formFields?.[1]?.options || [];
+    if (!registrationData.city && cityOptions.length) {
+      const defaultCity = cityOptions.find(opt => opt.selected) || cityOptions[0];
+      if (defaultCity?.cityName) {
+        dispatch(setRegistrationData({ city: defaultCity.cityName }));
+      }
+    }
+  }, [dispatch, formFields, registrationData.city]);
+
+  const validateField = useCallback((key, value) => {
     switch (key) {
       case 'username':
         return value.trim().length >= 6 ? '' : messages.usernameMin;
@@ -34,7 +44,7 @@ export default function ProfileRegistrationPage() {
       default:
         return '';
     }
-  };
+  }, [messages.contactInvalid, messages.usernameMin]);
 
   useEffect(() => {
     const usernameError = validateField('username', registrationData.username);
@@ -43,10 +53,11 @@ export default function ProfileRegistrationPage() {
     setErrors({ username: usernameError, contact: contactError });
 
     const baseValid = registrationData.email && registrationData.password;
-    const profileValid = registrationData.username && registrationData.contact;
+    const profileValid =
+      registrationData.username && registrationData.contact && registrationData.city;
 
     setIsFormValid(baseValid && profileValid && !usernameError && !contactError);
-  }, [registrationData]);
+  }, [registrationData, validateField]);
 
   const handleChange = (key, value) => {
     dispatch(setRegistrationData({ [key]: value }));
@@ -88,7 +99,7 @@ export default function ProfileRegistrationPage() {
               <label className="registration__label">{formFields[1].label}</label>
               <CustomSelect
                 options={formFields[1].options}
-                selected={formFields[1].options.find(opt => opt.value === registrationData.city)}
+                selected={formFields[1].options.find(opt => opt.cityName === registrationData.city)}
                 onChange={(selectedOption) => handleChange('city', selectedOption.cityName)}
               />
             </li>

--- a/src/pages/user-profile/index.jsx
+++ b/src/pages/user-profile/index.jsx
@@ -50,6 +50,11 @@ export default function UserProfile() {
       navigate('/signup');
       return;
     }
+    if (!registrationData.city) {
+      setError(authMessages?.cityRequired || 'Пожалуйста, выберите город');
+      navigate('/registration');
+      return;
+    }
     if (!registrationData.username || !registrationData.contact) {
       setError(authMessages?.contactInvalid || 'Пожалуйста, заполните данные профиля');
       navigate('/registration');
@@ -68,9 +73,7 @@ export default function UserProfile() {
       if (registrationData.avatarFile) {
         formData.append('avatar', registrationData.avatarFile);
       }
-      await apiClient.post('/auth/register', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      await apiClient.post('/auth/register', formData);
       navigate('/success');
     } catch (err) {
       const msg = getErrorMessage(err, 'Ошибка сервера');

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- point the frontend at the deployed backend without credentials to avoid CORS failures during registration
- improve registration form defaults/validation and custom select state to ensure required fields (including city) are captured before submitting
- add a Vercel rewrite to keep SPA routes like /user-profile working after refresh

## Testing
- npm run lint (reports existing hook-deps warnings in other files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530c087b80832d85e972713637e3f5)