### PR TITLE
Make backend API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ The application demonstrates practical frontend development skills using modern 
 
 ---
 
+## 🔧 Environment configuration
+
+Set these variables in a `.env` file (or in your hosting provider) to point the frontend to the correct backend:
+
+- `VITE_BACKEND_URL` — base backend host (for example `https://4-pets-backend.vercel.app`).
+- `VITE_BACKEND_PREFIX` — optional path prefix. Leave empty (`""`) if the host already includes the API path, or set to `/api/v1` (default) when the backend exposes versioned routes.
+
+---
+
 ## 📫 Contact
 
 If you have any questions or want to collaborate, feel free to reach out:

--- a/src/api.js
+++ b/src/api.js
@@ -1,14 +1,26 @@
 import axios from 'axios';
 
 const normalizeUrl = (value) => (value || '').replace(/\/+$/, '');
-const ensureApiPrefix = (value) => {
-  const normalized = normalizeUrl(value || '');
-  if (/\/api($|\/)/i.test(normalized)) return normalized;
-  return `${normalized}/api`;
-};
 
-export const API_BASE_URL = ensureApiPrefix(
-  import.meta.env.VITE_BACKEND_URL || 'https://4-pets-backend.vercel.app'
+const DEFAULT_BASE_URL = 'https://4-pets-backend.vercel.app';
+const DEFAULT_PREFIX = '/api/v1';
+
+const rawBaseUrl = normalizeUrl(import.meta.env.VITE_BACKEND_URL || DEFAULT_BASE_URL);
+const hasApiSegment = /\/api($|\/)/i.test(rawBaseUrl);
+
+const configuredPrefix = import.meta.env.VITE_BACKEND_PREFIX;
+const prefixToUse = configuredPrefix === ''
+  ? ''
+  : configuredPrefix || (hasApiSegment ? '' : DEFAULT_PREFIX);
+
+const normalizedPrefix = prefixToUse
+  ? `/${prefixToUse.replace(/^\/+/, '').replace(/\/+$/, '')}`
+  : '';
+
+export const API_BASE_URL = normalizeUrl(
+  normalizedPrefix && !rawBaseUrl.endsWith(normalizedPrefix)
+    ? `${rawBaseUrl}${normalizedPrefix}`
+    : rawBaseUrl
 );
 
 const readStoredToken = () => {


### PR DESCRIPTION
## Summary
- make backend URL selection configurable via optional prefix rather than forcing a hardcoded /api path
- document backend URL and prefix environment variables in the README for deployment setup

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531059a5cc832d82704c1e89a3c927)