### PR TITLE
Fix backend API URL prefix handling

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -13,9 +13,18 @@ const prefixToUse = configuredPrefix === ''
   ? ''
   : configuredPrefix || (hasApiSegment ? '' : DEFAULT_PREFIX);
 
-const normalizedPrefix = prefixToUse
-  ? `/${prefixToUse.replace(/^\/+/, '').replace(/\/+$/, '')}`
-  : '';
+const normalizePrefix = (value) => {
+  if (!value) return '';
+  const cleaned = `/${String(value).replace(/^\/+/, '').replace(/\/+$/, '')}`;
+
+  if (hasApiSegment || cleaned.startsWith('/api')) {
+    return cleaned;
+  }
+
+  return cleaned === '/api' ? cleaned : `/api${cleaned}`;
+};
+
+const normalizedPrefix = normalizePrefix(prefixToUse);
 
 export const API_BASE_URL = normalizeUrl(
   normalizedPrefix && !rawBaseUrl.endsWith(normalizedPrefix)


### PR DESCRIPTION
## Summary
- normalize backend prefix handling so /api is added when missing and avoid double prefixes

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531525b890832d98fe062d69e3128c)