### PR TITLE
Point frontend at backend root by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The application demonstrates practical frontend development skills using modern 
 Set these variables in a `.env` file (or in your hosting provider) to point the frontend to the correct backend:
 
 - `VITE_BACKEND_URL` — base backend host (for example `https://4-pets-backend.vercel.app`).
-- `VITE_BACKEND_PREFIX` — optional path prefix. Leave empty (`""`) if the host already includes the API path, or set to `/api/v1` (default) when the backend exposes versioned routes.
+- `VITE_BACKEND_PREFIX` — optional path prefix. Leave empty (`""`) if the host already includes the API path. By default the frontend now sends requests directly to the host root; specify `/api` or `/api/v1` only when your backend is mounted under that path.
 
 ---
 

--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 const normalizeUrl = (value) => (value || '').replace(/\/+$/, '');
 
 const DEFAULT_BASE_URL = 'https://4-pets-backend.vercel.app';
-const DEFAULT_PREFIX = '/api/v1';
+const DEFAULT_PREFIX = '';
 
 const rawBaseUrl = normalizeUrl(import.meta.env.VITE_BACKEND_URL || DEFAULT_BASE_URL);
 const hasApiSegment = /\/api($|\/)/i.test(rawBaseUrl);
@@ -11,7 +11,7 @@ const hasApiSegment = /\/api($|\/)/i.test(rawBaseUrl);
 const configuredPrefix = import.meta.env.VITE_BACKEND_PREFIX;
 const prefixToUse = configuredPrefix === ''
   ? ''
-  : configuredPrefix || (hasApiSegment ? '' : DEFAULT_PREFIX);
+  : configuredPrefix ?? (hasApiSegment ? '' : DEFAULT_PREFIX);
 
 const normalizePrefix = (value) => {
   if (!value) return '';


### PR DESCRIPTION
## Summary
- point the frontend API client at the backend root by default to match the deployed service
- clarify environment variable guidance for optional API prefix configuration

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695319ea6540832da0f57b8914691f72)