### PR TITLE
Fix chatbot request payload and response handling

### DIFF
--- a/src/authPages/chatbot/index.jsx
+++ b/src/authPages/chatbot/index.jsx
@@ -116,7 +116,7 @@ export default function ChatBot() {
             const res = await apiClient.post(
                 '/gpt/ask',
                 {
-                    message: trimmed,
+                    prompt: trimmed,
                     timestamp: isoTimestamp,
                 },
                 {
@@ -127,8 +127,15 @@ export default function ChatBot() {
             const botText =
                 res.data?.response ||
                 res.data?.data?.response ||
+                res.data?.message ||
+                res.data?.data?.message ||
                 res.data?.answer ||
                 "Ответ пустой 🤖";
+
+            const responseTimestamp =
+                res.data?.timestamp ||
+                res.data?.data?.timestamp ||
+                isoTimestamp;
 
             setMessages((prev) => [
                 ...prev.filter((msg) => !msg.isThinking),
@@ -136,7 +143,7 @@ export default function ChatBot() {
                     id: Date.now() + 2,
                     role: "bot",
                     text: botText,
-                    timestamp: isoTimestamp,
+                    timestamp: responseTimestamp,
                 },
             ]);
         } catch (error) {


### PR DESCRIPTION
## Summary
- send the chatbot request using the prompt field expected by the backend instead of message
- read backend message/timestamp fields when present so bot replies display the returned content

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538f878124832daf211269e86eefcb)