### PR TITLE
Harden client-side content handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@reduxjs/toolkit": "^2.8.2",
         "@tanstack/react-query": "^5.80.10",
         "axios": "^1.9.0",
+        "dompurify": "^3.1.6",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "node-fetch": "^3.3.2",
@@ -1967,6 +1968,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -2422,6 +2430,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@reduxjs/toolkit": "^2.8.2",
     "@tanstack/react-query": "^5.80.10",
     "axios": "^1.9.0",
+    "dompurify": "^3.1.6",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "node-fetch": "^3.3.2",

--- a/src/authComponents/blog/ArticleCard.jsx
+++ b/src/authComponents/blog/ArticleCard.jsx
@@ -1,23 +1,30 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { sanitizeHtml, sanitizeUrl } from '../../utils/security';
 
 
 export default React.memo(function ArticleCard({ article, readMoreText }) {
     const [expanded, setExpanded] = useState(false);
+    const safeLink = useMemo(
+        () => sanitizeUrl(article.link, { defaultValue: '#', allowHash: true }),
+        [article.link]
+    );
+    const sanitizedBody = useMemo(() => sanitizeHtml(article.body), [article.body]);
 
     const handleMore = () => setExpanded(!expanded);
-    const body = article.body;
 
     return (
         <div className={`article-card ${expanded ? 'expanded' : ''}`}>
             <div className="article-author">
                 <strong>{article.author}</strong>
-                <a href="#">{article.link}</a>
+                <a href={safeLink} rel="noopener noreferrer">
+                    {article.link}
+                </a>
                 <p className="article-date">{article.date}</p>
             </div>
             <p className="article-title">{article.title}</p>
             <p
                 className="article-body"
-                dangerouslySetInnerHTML={{ __html: body }}
+                dangerouslySetInnerHTML={{ __html: sanitizedBody }}
             />
             {!expanded && (
                 <button className="more-button" onClick={handleMore} type="button">

--- a/src/authComponents/blog/BlogPost.jsx
+++ b/src/authComponents/blog/BlogPost.jsx
@@ -1,13 +1,20 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { sanitizeHtml, sanitizeImageUrl } from '../../utils/security';
  
 export default React.memo(function BlogPost({ post }) {
     const [liked, setLiked] = useState(false);
+    const sanitizedText = useMemo(
+        () => (Array.isArray(post.text) ? post.text.map((p) => sanitizeHtml(p)) : []),
+        [post.text]
+    );
+    const avatarSrc = useMemo(() => sanitizeImageUrl(post.avatar), [post.avatar]);
+    const imageSrc = useMemo(() => sanitizeImageUrl(post.image), [post.image]);
 
     return (
         <div className="blog-post">
             <div className="post-header">
                 <div className="post-user">
-                    <img src={post.avatar} alt="avatar" className="avatar" />
+                    <img src={avatarSrc} alt="avatar" className="avatar" />
                     <div>
                         <strong>{post.nickname}</strong>
                         <div className="post-location">{post.location}</div>
@@ -16,9 +23,9 @@ export default React.memo(function BlogPost({ post }) {
                 <div className="post-caption">{post.caption}</div>
             </div>
             <div className="post-image-block">
-                <img src={post.image} alt="Post" className="post-image" loading="lazy" />
+                <img src={imageSrc} alt="Post" className="post-image" loading="lazy" />
                 <div className="post-overlay-text">
-                    {post.text.map((p, idx) => (
+                    {sanitizedText.map((p, idx) => (
                         <p key={idx} dangerouslySetInnerHTML={{ __html: p }} />
                     ))}
                 </div>

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -22,8 +22,8 @@ const Footer = forwardRef((props, ref) => {
                             <InstagramIcon/>
                         </div>
                         <div className="footer__instagram-links-block">
-                            <a href="https://www.instagram.com/4petssss/" target="blank">@4petssss</a>
-                            <a href="https://www.instagram.com/tsi.auca.kg/" target="blank">@tsiauca.kg</a>
+                            <a href="https://www.instagram.com/4petssss/" target="_blank" rel="noopener noreferrer">@4petssss</a>
+                            <a href="https://www.instagram.com/tsi.auca.kg/" target="_blank" rel="noopener noreferrer">@tsiauca.kg</a>
                         </div>
                     </div>
                     <div className="footer__contacts-info">

--- a/src/utils/security.js
+++ b/src/utils/security.js
@@ -1,0 +1,42 @@
+import DOMPurify from 'dompurify';
+
+const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+const resolveBaseOrigin = () => {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'http://localhost';
+};
+
+export const sanitizeHtml = (dirty = '') =>
+  DOMPurify.sanitize(dirty, {
+    USE_PROFILES: { html: true },
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel):|[^a-z]|[a-z+.-]+(?:[^a-z+.-]|$))/i,
+    FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'form'],
+  });
+
+export const sanitizeUrl = (value, { defaultValue = '', allowHash = true } = {}) => {
+  if (!value) return defaultValue;
+
+  const trimmed = String(value).trim();
+  if (allowHash && trimmed.startsWith('#')) {
+    return `#${trimmed.replace(/^#+/, '')}`;
+  }
+
+  try {
+    const baseOrigin = resolveBaseOrigin();
+    const parsed = new URL(trimmed, baseOrigin);
+
+    if (SAFE_URL_PROTOCOLS.has(parsed.protocol)) {
+      return parsed.toString();
+    }
+  } catch {
+    // noop: fall through to defaultValue
+  }
+
+  return defaultValue;
+};
+
+export const sanitizeImageUrl = (value) =>
+  sanitizeUrl(value, { defaultValue: '', allowHash: false });


### PR DESCRIPTION
## Summary
- add DOMPurify-based sanitization helpers for HTML, image sources, and links
- use the helpers in blog posts and article cards to prevent unsafe markup and URLs from rendering
- add safety attributes to external Instagram links

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695964be5b80832d98b09ddd6f054ba5)