### PR TITLE
Improve auth validation feedback

### DIFF
--- a/src/authPages/chatbot/index.jsx
+++ b/src/authPages/chatbot/index.jsx
@@ -201,7 +201,7 @@ export default function ChatBot() {
             setIsLoading(false);
             setMessages([]);
         }
-    }, [token, chatBotContent.emptyDataText, chatBotContent.loadingHistory]);
+    }, [token, chatBotContent]);
 
     const sendMessage = async () => {
         const trimmed = input.trim();

--- a/src/components/input/style.scss
+++ b/src/components/input/style.scss
@@ -28,7 +28,7 @@
   }
 
   &.input-success {
-    border-color: #2e7d32 !important;
+    border-color: #0b780a !important;
   }
 }
 
@@ -50,7 +50,7 @@
 }
 
 .input__helper-text.input-success {
-  color: #00ff00 !important;
+  color: #0b780a !important;
   opacity: 1;
   transform: translateY(0);
 }

--- a/src/pages/auth-form/index.jsx
+++ b/src/pages/auth-form/index.jsx
@@ -45,14 +45,9 @@ export default function AuthLayout({ currentForm }) {
     },
   });
 
-  const passwordValue = watch('password');
+  const passwordValue = watch('password') || '';
 
   useEffect(() => {
-    if (currentForm === 'login') {
-      setCriteriaStatus({ length: true, digits: true });
-      setPasswordStrength('strong');
-      return;
-    }
     const hasLength = passwordValue.length >= 8;
     const hasDigits = /\d/.test(passwordValue) && /[^A-Za-z0-9]/.test(passwordValue);
     setCriteriaStatus({ length: hasLength, digits: hasDigits });
@@ -64,7 +59,7 @@ export default function AuthLayout({ currentForm }) {
       strength = 'medium';
     }
     setPasswordStrength(strength);
-  }, [passwordValue, currentForm]);
+  }, [passwordValue]);
 
 
   const loginMutation = useMutation({

--- a/src/pages/auth-form/style.scss
+++ b/src/pages/auth-form/style.scss
@@ -133,11 +133,11 @@
 }
 
 .valid {
-  color: #00ff00;
+  color: #0b780a;
   font-weight: 500;
 
   svg, path {
-    stroke: #00ff00 !important;
+    stroke: #0b780a !important;
   }
 }
 
@@ -151,18 +151,30 @@
 }
 
 .password-strong {
-  color: #2e7d32;
+  color: #0b780a;
   font-weight: bold;
+
+  svg, path {
+    stroke: #0b780a !important;
+  }
 }
 
 .password-medium {
   color: #fbc02d;
   font-weight: bold;
+
+  svg, path {
+    stroke: #fbc02d !important;
+  }
 }
 
 .password-weak {
   color: #d32f2f;
   font-weight: bold;
+
+  svg, path {
+    stroke: #d32f2f !important;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Ensure login and signup password hints reflect the current input instead of forcing a strong state.
- Refresh validation success styling to the requested #0b780a across checklist items and inputs.
- Keep chatbot history loading in sync with translated copy by tracking the full content object.

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596a332920832db5653d57b1cb5e5d)