### PR TITLE
Make validation checkmarks inherit text color

### DIFF
--- a/src/svg_pictures/check-mark-icon.jsx
+++ b/src/svg_pictures/check-mark-icon.jsx
@@ -12,8 +12,7 @@ function CheckMarkIcon() {
     >
       <path
         d="M12.333 1.24L5 8.573 1.667 5.24"
-        stroke="#465FF1"
-        strokeOpacity={0.25}
+        stroke="currentColor"
         strokeWidth={1.5}
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
## Summary
- make the validation checkmark icon use the current text color instead of a fixed, semi-transparent stroke
- ensure the icon stroke is fully opaque so it matches the accompanying validation text state

## Testing
- npm run dev -- --host --port 4173


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596cf07c64832d95db23e0ee266f7d)